### PR TITLE
[Feature] Phase-field fracture models, Shell script

### DIFF
--- a/installDependencies.sh
+++ b/installDependencies.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Check if the operating system is Linux
+
+if [[ "$(uname)" == "Linux" ]]; then
+    echo "Found Linux OS"
+    echo "Installation with proceed ..."
+        printf "\n\n"
+else
+    echo "Script works only on Linux"
+    exit 1;
+fi
+
+# Ask user if it is okay to install some libraries
+# in the root directory (/usr/lib) and (/usr/include)
+
+read -p "Dependencies will be installed to /usr directory. Do you want to proceed? (Y/N): " choice
+
+# Check if the user wants to proceed
+if [[ $choice == "y" ]]; then
+    
+    echo "Installing dependencies: build-essential g++ zlib1g-dev libreadline-dev freeglut3-dev"
+    sudo apt-get install -y git build-essential g++ zlib1g-dev libreadline-dev freeglut3-dev
+    
+    printf "\n\n"
+    echo "Downloading Jem and Jive, version 3.0"
+    cd ..
+    git clone https://github.com/ritukeshbharali/jemjive-3.0.git
+    
+    read -p "Do you want to install the MPI version? (Y/N): " choice
+    
+    if [[ $choice == "y" ]]; then
+        
+        sudo apt-get install openmpi-bin openmpi-common libopenmpi-dev
+        
+        cd ./jemjive-3.0/jem-3.0 && ./configure --cxx=mpic++ && make -j5
+        printf "\n\n"
+        echo "Built MPI jem library"
+        echo $(pwd)    
+        export JEMDIR=$(pwd)
+        
+    else
+    
+        cd ./jemjive-3.0/jem-3.0 && ./configure && make -j5
+        printf "\n\n"
+        echo "Built Multithreaded jem library"
+        echo $(pwd)    
+        export JEMDIR=$(pwd)
+        
+   fi
+            
+    cd ../jive-3.0 && ./configure && make -j5
+    echo $(pwd)
+    export JIVEDIR=$(pwd)
+    cd ../../
+    
+    printf "\n\n"
+    echo "Export these environment variables for future simulations:"
+    echo "export JEMDIR='$JEMDIR'"
+    echo "export JIVEDIR='$JIVEDIR'"
+    
+else
+
+   exit 1;    
+    
+fi    
+    
+    
+    

--- a/src/fem/solidmech/MicroPhaseFractureModel.cpp
+++ b/src/fem/solidmech/MicroPhaseFractureModel.cpp
@@ -474,7 +474,7 @@ bool MicroPhaseFractureModel::takeAction
   
   if ( action == ArclenActions::GET_ARC_FUNC && arcLenMode_ )
   {
-    getDissipation_ ( params, globdat );
+    getArcFunc_ ( params, globdat );
 
     return true;
   }
@@ -1162,10 +1162,10 @@ void MicroPhaseFractureModel::getMatrix2_
 
 
 //-----------------------------------------------------------------------
-//   getDissipation_
+//   getArcFunc_
 //-----------------------------------------------------------------------
 
-void MicroPhaseFractureModel::getDissipation_
+void MicroPhaseFractureModel::getArcFunc_
 
   ( const Properties&  params,
     const Properties&  globdat )

--- a/src/fem/solidmech/MicroPhaseFractureModel.h
+++ b/src/fem/solidmech/MicroPhaseFractureModel.h
@@ -176,7 +176,7 @@ class MicroPhaseFractureModel : public Model
 
     ( MatrixBuilder&          mbuilder );
 
-  void                      getDissipation_
+  void                      getArcFunc_
 
     ( const Properties&       params,
       const Properties&       globdat );  

--- a/src/fem/solidmech/PhaseFractureModel.cpp
+++ b/src/fem/solidmech/PhaseFractureModel.cpp
@@ -449,6 +449,16 @@ bool PhaseFractureModel::takeAction
     return true;
   }
 
+  /** GET_ARC_FUNC: Requests the arc-length function
+   */ 
+  
+  if ( action == ArclenActions::GET_ARC_FUNC && arcLenMode_ )
+  {
+    getArcFunc_ ( params, globdat );
+
+    return true;
+  }
+
   /** COMMIT: Requests an action when a computation step has converged.
    *  Ideally, at this point, the material internal state variables
    *  are swapped.

--- a/src/fem/solidmech/PhaseFractureModel.cpp
+++ b/src/fem/solidmech/PhaseFractureModel.cpp
@@ -391,6 +391,7 @@ bool PhaseFractureModel::takeAction
   using jive::model::Actions;
   using jive::model::ActionParams;
   using jive::model::StateVector;
+  using jive::implict::ArclenActions;
 
   // Compute the internal force vector
 


### PR DESCRIPTION
## Summary

Phase-field fracture models were updated. In the extrapolation-based models, a fixed point iteration is added to correct the extrapolation error. In other models, getArcFunc_ function was fixed so that it works with arclen solver. Also, a shell script is added, which installs all dependencies.

Fixes # (none)

## New Feature(s)
- [ fem ] PhaseFractureModel and MicroPhaseFractureModel has getArcFunc for arclen solver
- [ fem ] PhaseFractureExtModel and MicroPhaseFractureExtModel has an additional fixed point iteration step
- [ shell ] Installs all dependencies

## Type of change
- [x] New feature  
- [x] Change requires a documentation update