### PR TITLE
[Fix] Makefile and redundant headers

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -968,7 +968,7 @@ EXCLUDE_SYMLINKS       = NO
 # Note that the wildcards are matched against the file with absolute path, so to
 # exclude all test directories for example use the pattern */test/*
 
-EXCLUDE_PATTERNS       =
+EXCLUDE_PATTERNS       = */amgcl/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/build/makefile.nolibs
+++ b/build/makefile.nolibs
@@ -17,5 +17,5 @@ include $(JIVEDIR)/makefiles/packages/*.mk
 MY_LIBS          = 
 MY_INCDIRS       = ../src
 MY_LIBDIRS	 = 
-MY_CXX_STD_FLAGS = -DWITH_AMGCL
+MY_CXX_STD_FLAGS = 
 MY_LD_FLAGS      = 

--- a/src/util/BasicUtils.h
+++ b/src/util/BasicUtils.h
@@ -25,9 +25,6 @@
 #include <vector>
 #include <map>
 
-#include <boost/lexical_cast.hpp>
-#include <boost/algorithm/string.hpp>
-
 namespace jem
 {
   namespace util


### PR DESCRIPTION
## Summary

Removed redundant header files in BasicUtils.h.
Removed WITH_AMGCL in makefile.nolibs