### PR TITLE
[Performance, Fix] Code clean-up and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Ubuntu Build Status](https://github.com/ritukeshbharali/falcon/actions/workflows/ci.yml/badge.svg)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/f42e24ea5ca64976a8212c7318f3e648)](https://app.codacy.com/gh/ritukeshbharali/falcon/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 falcon
 ================

--- a/build/makefile.nolibs
+++ b/build/makefile.nolibs
@@ -5,7 +5,8 @@ subdirs = ../src/constraints \
           $(wildcard ../src/fem/*/) \
           $(wildcard ../src/io/*/) \
           ../src/materials \
-          $(wildcard ../src/solvers/*/) \
+          ../src/solvers/implicit \
+          ../src/solvers/linear  \
           ../src/steppers \
           ../src/util
           

--- a/src/constraints/DirichletModel.cpp
+++ b/src/constraints/DirichletModel.cpp
@@ -73,6 +73,7 @@ DirichletModel::DirichletModel
     Super ( name )
 
 {
+  ngroups_  = 0;
   stepSize_ = 0.0;
   total_    = total0_ = 0.0;
 }

--- a/src/fem/solidmech/MicroPhaseFractureExtModel.cpp
+++ b/src/fem/solidmech/MicroPhaseFractureExtModel.cpp
@@ -268,6 +268,8 @@ MicroPhaseFractureExtModel::MicroPhaseFractureExtModel
 
   dt_          = 0.0;
   dt0_         = 0.0;
+
+  extFail_     = false;
 }
 
 
@@ -722,7 +724,7 @@ void MicroPhaseFractureExtModel::getIntForce_
       double Res         = dgphi * Psi + gc_/(cw_*l0_)*dw + alpha * ( d - pfEx );
       double J           = ddgphi * Psi + gc_/(cw_*l0_)*ddw + alpha;
 
-      int iter = 0;
+      // int iter = 0;
 
       // Carry out the iterative procedure
 
@@ -730,7 +732,7 @@ void MicroPhaseFractureExtModel::getIntForce_
       {
 
         // Increase iteration counter 
-        iter   += 1;        
+        // iter   += 1;        
         
         // Update local phase-field
         d      -= Res/J;
@@ -795,7 +797,7 @@ void MicroPhaseFractureExtModel::getIntForce_
         ddgphi    = ( ( ddgphi_n * gphi_d - gphi_n * ddgphi_d ) * gphi_d - 2.0 * 
                            ( dgphi_n * gphi_d - gphi_n * dgphi_d ) * dgphi_d ) / ( gphi_d * gphi_d * gphi_d );  
 
-        dw        = eta_ + 2.0 * ( 1.0 - eta_ ) * d;
+        // dw        = eta_ + 2.0 * ( 1.0 - eta_ ) * d;
         ddw       = 2.0 * ( 1.0 - eta_ );
 
         // Compute the degradation function derivatives with the current phase-field
@@ -850,7 +852,7 @@ void MicroPhaseFractureExtModel::getIntForce_
       Res         = dgphi * Psi + gc_/(cw_*l0_)*dw + alpha * ( d - pf );
       J           = ddgphi * Psi + gc_/(cw_*l0_)*ddw + alpha;
    
-      iter = 0;
+      // iter = 0;
 
       // Carry out the iterative procedure
 
@@ -858,7 +860,7 @@ void MicroPhaseFractureExtModel::getIntForce_
       {
 
         // Increase iteration counter 
-        iter   += 1;        
+        // iter   += 1;        
         
         // Update local phase-field
         d      -= Res/J;
@@ -913,7 +915,7 @@ void MicroPhaseFractureExtModel::getIntForce_
         ddgphi    = ( ( ddgphi_n * gphi_d - gphi_n * ddgphi_d ) * gphi_d - 2.0 * 
                            ( dgphi_n * gphi_d - gphi_n * dgphi_d ) * dgphi_d ) / ( gphi_d * gphi_d * gphi_d );  
 
-        dw        = eta_ + 2.0 * ( 1.0 - eta_ ) * d;
+        // dw        = eta_ + 2.0 * ( 1.0 - eta_ ) * d;
         ddw       = 2.0 * ( 1.0 - eta_ );
 
         // Compute the degradation function derivatives with the current phase-field
@@ -1161,7 +1163,7 @@ void MicroPhaseFractureExtModel::getMatrix_
       double Res         = dgphi * Psi + gc_/(cw_*l0_)*dw + alpha * ( d - pfEx );
       double J           = ddgphi * Psi + gc_/(cw_*l0_)*ddw + alpha;
 
-      int iter = 0;
+      // int iter = 0;
 
       // Carry out the iterative procedure
 
@@ -1169,7 +1171,7 @@ void MicroPhaseFractureExtModel::getMatrix_
       {
 
         // Increase iteration counter 
-        iter   += 1;        
+        // iter   += 1;        
         
         // Update local phase-field
         d      -= Res/J;
@@ -1254,7 +1256,7 @@ void MicroPhaseFractureExtModel::getMatrix_
       Res         = dgphi * Psi + gc_/(cw_*l0_)*dw + alpha * ( d - pf );
       J           = ddgphi * Psi + gc_/(cw_*l0_)*ddw + alpha;
    
-      iter = 0;
+      // iter = 0;
 
       // Carry out the iterative procedure
 
@@ -1262,7 +1264,7 @@ void MicroPhaseFractureExtModel::getMatrix_
       {
 
         // Increase iteration counter 
-        iter   += 1;        
+        // iter   += 1;        
         
         // Update local phase-field
         d      -= Res/J;

--- a/src/fem/solidmech/MicroPhaseFractureModel.cpp
+++ b/src/fem/solidmech/MicroPhaseFractureModel.cpp
@@ -660,7 +660,7 @@ void MicroPhaseFractureModel::getIntForce_
       double Res         = dgphi * Psi + gc_/(cw_*l0_)*dw + alpha * ( d - pf );
       double J           = ddgphi * Psi + gc_/(cw_*l0_)*ddw + alpha;
 
-      int iter = 0;
+      // int iter = 0;
 
       // Carry out the iterative procedure
 
@@ -668,7 +668,7 @@ void MicroPhaseFractureModel::getIntForce_
       {
 
         // Increase iteration counter 
-        iter   += 1;        
+        // iter   += 1;        
         
         // Update local phase-field
         d      -= Res/J;
@@ -931,7 +931,7 @@ void MicroPhaseFractureModel::getMatrix_
       double Res         = dgphi * Psi + gc_/(cw_*l0_)*dw + alpha * ( d - pf );
       double J           = ddgphi * Psi + gc_/(cw_*l0_)*ddw + alpha;
 
-      int iter = 0;
+      // int iter = 0;
 
       // Carry out the iterative procedure
 
@@ -939,7 +939,7 @@ void MicroPhaseFractureModel::getMatrix_
       {
 
         // Increase iteration counter 
-        iter   += 1;        
+        // iter   += 1;        
         
         // Update local phase-field
         d      -= Res/J;
@@ -982,8 +982,8 @@ void MicroPhaseFractureModel::getMatrix_
         // Compute the required quantities
 
         gphi_n  = ::pow( 1.0 - d, p_);
-        gphi_d  = gphi_n + a1_*d + a1_*a2_*d*d + 
-                             a1_*a2_*a3_*d*d*d;
+        // gphi_d  = gphi_n + a1_*d + a1_*a2_*d*d + 
+        //                      a1_*a2_*a3_*d*d*d;
 
         dgphi_n   = - p_ * ( ::pow( 1.0 - d, p_- 1.0 ) );
         dgphi_d   = dgphi_n + a1_ + 2.0*a1_*a2_*d + 3.0*a1_*a2_*a3_*d*d;
@@ -996,7 +996,7 @@ void MicroPhaseFractureModel::getMatrix_
         ddgphi    = ( ( ddgphi_n * gphi_d - gphi_n * ddgphi_d ) * gphi_d - 2.0 * 
                            ( dgphi_n * gphi_d - gphi_n * dgphi_d ) * dgphi_d ) / ( gphi_d * gphi_d * gphi_d );  
 
-        dw        = eta_ + 2.0 * ( 1.0 - eta_ ) * d;
+        // dw        = eta_ + 2.0 * ( 1.0 - eta_ ) * d;
         ddw       = 2.0 * ( 1.0 - eta_ );
 
         // Compute the degradation function derivatives with the current phase-field

--- a/src/fem/solidmech/PhaseFractureExtModel.cpp
+++ b/src/fem/solidmech/PhaseFractureExtModel.cpp
@@ -269,6 +269,8 @@ PhaseFractureExtModel::PhaseFractureExtModel
 
   dt_          = 0.0;
   dt0_         = 0.0;
+
+  extFail_     = false;
 }
 
 

--- a/src/io/models/LodiModel.cpp
+++ b/src/io/models/LodiModel.cpp
@@ -138,7 +138,7 @@ void LodiModel::configure
     inodes_ = nGroup.getIndices ( );
   }
 
-  if ( !nodes & !group )
+  if ( !(nodes) && !(group) )
   {
      myProps.propertyError ( context,
 			     "must specify nodes or node group!!!" );
@@ -249,8 +249,8 @@ bool LodiModel::takeAction
     Vector fint1 = fint.clone();
 
     
-    Vector      mass;
-    bool hasMass = globdat.find ( mass, "massVector" );
+    // Vector      mass;
+    // bool hasMass = globdat.find ( mass, "massVector" );
 
     // if ( !hasMass )
     // {

--- a/src/io/modules/VTKWriterModule.cpp
+++ b/src/io/modules/VTKWriterModule.cpp
@@ -101,7 +101,9 @@ const char*  VTKWriterModule::DATA_TYPE_PROP    = "dataType";
 
 VTKWriterModule::VTKWriterModule ( const String& name ) :
   Super ( name )
-{}
+{
+  nProcs_ = 1;
+}
 
 VTKWriterModule::~VTKWriterModule ()
 {}

--- a/src/materials/AmorPhaseMaterial.cpp
+++ b/src/materials/AmorPhaseMaterial.cpp
@@ -57,9 +57,12 @@ AmorPhaseMaterial::AmorPhaseMaterial
 
   young_   = 1.0;
   poisson_ = 1.0;
+  K_       = 1.0;
 
   stressP_.resize( STRAIN_COUNTS[rank_] );
+  
   stressP_ = 0.0;
+  Psi_     = 0.0;
 }
 
 

--- a/src/materials/BourdinPhaseMaterial.cpp
+++ b/src/materials/BourdinPhaseMaterial.cpp
@@ -60,7 +60,9 @@ BourdinPhaseMaterial::BourdinPhaseMaterial
   elasticStiffMat_ = 0.0;
 
   stressP_.resize( STRAIN_COUNTS[rank_] );
+  
   stressP_ = 0.0;
+  Psi_     = 0.0;
 }
 
 

--- a/src/materials/LiakopoulosRetentionMaterial.h
+++ b/src/materials/LiakopoulosRetentionMaterial.h
@@ -88,15 +88,6 @@ class LiakopoulosRetentionMaterial : public RetentionMaterial
 
   virtual                ~LiakopoulosRetentionMaterial   ();
 
- protected:
-
-  // Material properties
-
-  double                  aVG_;
-  double                  eVG_;
-  double                  jVG_;
-  double                  sRes_;
-
 };
 
 #endif 

--- a/src/materials/Material.cpp
+++ b/src/materials/Material.cpp
@@ -25,6 +25,9 @@ Material::Material
 {
   desperateMode_ = false;
   rank_          = rank;
+
+  young_         = 1.0;
+  poisson_       = 0.0;
 }
 
 Material::~Material()

--- a/src/materials/RetentionMaterial.cpp
+++ b/src/materials/RetentionMaterial.cpp
@@ -19,7 +19,9 @@ using namespace jem;
 RetentionMaterial::RetentionMaterial
 
   ( const Properties&  globdat )
-{}
+{
+  rho_ = 1.0;
+}
 
 RetentionMaterial::~RetentionMaterial()
 {}

--- a/src/steppers/AdaptiveSteppingModule.cpp
+++ b/src/steppers/AdaptiveSteppingModule.cpp
@@ -116,39 +116,40 @@ AdaptiveSteppingModule::AdaptiveSteppingModule
   ( const String&  name,
     Ref<SolverModule>  solver ) :
 
-      Super    ( name   ),
-      solver_  ( solver )
+      Super       ( name   ),
+      solver_     ( solver ),
+      istep_      ( 0 ),
+      istep0_     ( 0 ),
+      nCancels_   ( 0 ),
+      nContinues_ ( 0 ),
+      maxNIter_   ( 0 ),
 
-{
-  istep_          = 0;
-  istep0_         = 0;
-  nCancels_       = 0;
-  nContinues_     = 0;
-  maxNIter_       = 0;
+      nRunTotal_  ( 0 ),
+      nCancTotal_ ( 0 ),
+      nContTotal_ ( 0 ),
+      nIterTotal_ ( 0 ),
+      nCancCont_  ( 0 ),
+      nCommTotal_ ( 0 ),
 
-  nRunTotal_      = 0;
-  nCancTotal_     = 0;
-  nContTotal_     = 0;
-  nIterTotal_     = 0;
-  nCancCont_      = 0;
-  nCommTotal_     = 0;
+      startIncr_   ( 1. ),
+      minIncr_     ( 1.e-5 ),
+      maxIncr_     ( 1. ),
+      timeMax_     ( 1.e99 ),
+      timeA_       ( 1.e99 ),
+      timeB_       ( 1.e99 ),
+      reduction_   ( 0.45 ),
+      optIter_     ( 5 ),
+      increment0_  ( 0. ),
+      increment_   ( 0. ),
+      time0_       ( 0. ),
+      time_        ( 0. ),
 
-  startIncr_      = 1.;
-  minIncr_        = 1.e-5;
-  maxIncr_        = 1.;
-  timeMax_        = 1.e99;
-  timeA_          = 1.e99;
-  timeB_          = 1.e99;
-  reduction_      = 0.45;
-  optIter_        = 5;
-  increment0_     = 0.;
-  increment_      = 0.;
+      maxIncrTried_ (0. ),
+      writeStats_   (false ),
+      triedSmall_   (false ),
+      strict_       (false )
 
-  maxIncrTried_   = 0.;
-  writeStats_     = false;
-  triedSmall_     = false;
-  strict_         = false;
-}
+{}
 
 AdaptiveSteppingModule::~AdaptiveSteppingModule ()
 {}

--- a/src/steppers/ReduceSteppingModule.cpp
+++ b/src/steppers/ReduceSteppingModule.cpp
@@ -106,21 +106,18 @@ ReduceSteppingModule::ReduceSteppingModule
   ( const String&  name,
     Ref<SolverModule>  solver ) :
 
-      Super    ( name   ),
-      solver_  ( solver )
+      Super       ( name   ),
+      solver_     ( solver ),
+      istep_      ( 0 ),
+      istep0_     ( 0 ),
+      startIncr_  ( 1. ),
+      minIncr_    ( 1.e-5 ),
+      cutStep_    ( -1 ),
+      reduction_  ( 0.45 ),
+      increment0_ ( 0. ),
+      increment_  ( 0. )
 
-{
-  istep_          = 0;
-  istep0_         = 0;
-
-  startIncr_      = 1.;
-  minIncr_        = 1.e-5;
-  cutStep_        = -1;
-  reduction_      = 0.45;
-  
-  increment0_     = 0.;
-  increment_      = 0.;
-}
+{}
 
 ReduceSteppingModule::~ReduceSteppingModule ()
 {}

--- a/src/util/TbFiller.cpp
+++ b/src/util/TbFiller.cpp
@@ -64,11 +64,10 @@ IdxVector    TbFiller::permj2_        = IdxVector();
 
 TbFiller::TbFiller 
 
-    ( const idx_t       rank ) : rank_ ( rank )
+    ( const idx_t       rank ) : rank_ ( rank ), ntype_ ( 0 )
 
 {
   strCount_ = STRAIN_COUNTS[rank_];
-  ntype_    = 0;
 }
 
 TbFiller::~TbFiller ()

--- a/tests/do_tests.sh
+++ b/tests/do_tests.sh
@@ -12,7 +12,8 @@ passd=0
 faild=0
 
 for d in */ ; do
-    cd $d
+    cd "$d"
+    rm -f *.log *.dat *.pvd *.vtu
     i=$((i+1))
     echo "------------------------------------------------------- " | tee -a ../tests.log
     echo " Running problem $i of $num"                              | tee -a ../tests.log


### PR DESCRIPTION
## Summary

For phase-field models with extrapolations, the commit [ae38b66](https://github.com/ritukeshbharali/falcon/pull/5/commits/ae38b661a968e0d56ea49391d3599b1acaddee12) had a bug. extFail was not initialized. It is fixed now. 

The amgcl directory has been removed from makefile.nolibs. amgcl has openmp as backend, so build will fail without openmp. Jive and falcon does not require openmp for thread parallelization. Also some member initialization in different classes is moved to the initialization list instead of the constructor body.

Fixes: PhaseFractureExtModel, MicroPhaseFractureExtModel, makefile.nolibs

## Change(s)
- [ fem ] PhaseFractureExtModel and MicroPhaseFractureExtModel member extFail initialized to false
- [ makefile ] makefile.nolibs excludes amgcl

## Type of change
- [x] Fixes
- [x] Performance 