### PR TITLE
closes #21, NaN local residual fixed in micromorphic phase fracture ext model

### DIFF
--- a/demo/solidmech/microPhaseFieldFracture/sent/problem.pro
+++ b/demo/solidmech/microPhaseFieldFracture/sent/problem.pro
@@ -49,7 +49,7 @@ model = "Matrix"
   {
     models = ["bulk","cons","lodi"];
 
-    bulk = "MicroPhaseFracture"
+    bulk = "MicroPhaseFractureExt"
     {
       elements = "DomainElems";
 
@@ -112,25 +112,15 @@ extraModules =
 
     solver = "Nonlin"
     {
-      precision = 1.e-4;
-      maxIter = 50;
-      reformIter = 0;
-      lineSearch  = false;
-      bounds = ["b1"];
+      precision  = 1.e-3;
+      maxIter    = 2500;
+      //reformIter = 0;
+      lineSearch = false;
+      bounds     = ["b1"];
       solver =
       {
-        type = "GMRES";
-        precon.type="ILUd";
-        precon.reorder = true;
-        precon.maxFill = 3.00000;
-        precon.dropTol = 1.00000e-08;
-        precon.diagShift = 0.00000;
-        precon.zeroThreshold = 1.00000e-08;
-        precon.minSize = 0;
-        precon.quality = 1.00000;
-        precision = 1.0e-08;
-        //type = "SkylineLU";
-        //useThreads=true;
+        type = "SkylineLU";
+        useThreads=true;
       };
 
       b1 = 
@@ -140,27 +130,7 @@ extraModules =
          upperBound = 1.;
       };
     };
-
   };
-
-  /*  
-  solver = 
-  {
-      type = "Nonlin";
-    
-      precision = 1.0e-6;
-    
-      maxIter   = 100;
-  
-      solver =
-      {
-        //type = "GMRES";
-        type = "SkylineLU";
-        lenient = true;
-        useThreads = true;
-      };
-  };
-  */
 
   graph =
   {
@@ -241,13 +211,11 @@ extraModules =
 
   sample = "Sample"
   {
-    // Save load displacement data in file.
+    // Save iteration data in file.
     file = "$(CASE_NAME)_iter.dat";
-    //header = "  0.00000000e+00   0.00000000e+00   0.00000000e+00";
     dataSets = [ 
                  "i", 
-                 "solverInfo.iterCount"
-                 //"model.model.lodi.load[0]" 
+                 "solverInfo.iterCount" 
                ];
   };     
 

--- a/src/fem/solidmech/MicroPhaseFractureExtModel.h
+++ b/src/fem/solidmech/MicroPhaseFractureExtModel.h
@@ -1,7 +1,7 @@
 
 /** @file MicroPhaseFractureExtModel.h
- *  @brief Micromorphic phase-field fracture model with
- *         extrapolation.
+ *  @brief Micromorphic phase-field fracture model with 
+ *         extrapolation
  *  
  *  Author: R. Bharali, ritukesh.bharali@chalmers.se
  *  Date: 14 June 2022  
@@ -14,6 +14,9 @@
  *     - [25 December 2023] removed getIntForce_,
  *       getMatrix_ returns the internal force if
  *       mbuilder = nullptr. Eliminates duplicate code. (RB)
+ * 
+ *     - [03 April 2024] Fixed bug stalls the simulation
+ *       in the first step due to a NaN local residual. (RB)
  */
 
 /* Include c++ headers */
@@ -96,7 +99,7 @@ typedef ElementGroup           ElemGroup;
 /** @brief 
  *  The MicroPhaseFractureExtModel class implements a micromorphic phase
  *  -field fracture FE Model with extrapolation based convexification 
- *  technique. 
+ *  technique and subsequent corrective iterations. 
  *  <a href="https://link.springer.com/article/10.1007/s00466-023-02380-1" target="_blank">Link to Article</a>
  */
 
@@ -162,9 +165,7 @@ class MicroPhaseFractureExtModel : public Model
 
     ( Ref<MatrixBuilder>      mbuilder,
       const Vector&           force,
-      const Vector&           state,
-      const Vector&           state0,
-      const Vector&           state00 );
+      const Vector&           state    );
 
   void                      getMatrix2_
 
@@ -199,7 +200,8 @@ class MicroPhaseFractureExtModel : public Model
 
   void                      checkCommit_
 
-    ( const Properties&       params );  
+    ( const Properties&       params,
+      const Properties&       globdat );  
 
   /* Initialize the mapping between integration points
    * and material points 
@@ -283,10 +285,13 @@ class MicroPhaseFractureExtModel : public Model
 
   struct                  hist_
   {
-    Flex<double>            phasef_ ;     // phase-field variable
+    Flex<double>          phasef_ ;     // phase-field variable
   };
 
   hist_                   preHist_;      // history of the previous load step
   hist_                   newHist_;      // history of the current iteration
 
+  // Extrapolated state vector
+
+  Vector stateExt_;
 };


### PR DESCRIPTION
The local equation for the phase-field was returning NaN residuals in the first step of the simulation. This is fixed now.